### PR TITLE
fix: category cache bug

### DIFF
--- a/backend/category_product_list/service/index.py
+++ b/backend/category_product_list/service/index.py
@@ -6,7 +6,7 @@ class Service:
         self.dao = DAO()
 
     def select_product_list(self, cat_level_2_id, sort_order, page):
-        r_key = "category-product-list->{}->".format(cat_level_2_id, page)
+        r_key = "category-product-list->{}->{}".format(cat_level_2_id, page)
         if sort_order in ("asc", "desc"):
             r_key += "->{}".format(sort_order)
         product_list = self.dao.cache_ops.get(r_key)


### PR DESCRIPTION
add additional formatting bracket in category-product-list.py in order to accept page number in redis cache